### PR TITLE
Now return null if there is no SIM Card (UICC) in android device

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.0.2
+
+Now return null if there is no SIM Card (UICC) in android device (didn't return at all before).
+
 ## 1.0.1
 
 Updated readme

--- a/android/src/main/kotlin/com/example/device_region/DeviceRegionPlugin.kt
+++ b/android/src/main/kotlin/com/example/device_region/DeviceRegionPlugin.kt
@@ -36,7 +36,11 @@ class DeviceRegionPlugin: FlutterPlugin, MethodCallHandler {
             
             if (networkCountry != null && networkCountry.length == 2) { // network country code is available
                 result.success(networkCountry)
+            } else {
+              result.success(null)
             }
+        } else {
+          result.success(null)
         }
     }
     catch (e: Exception) {

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: device_region
 description: This plugin uses platform-specific API to return SIM country code
-version: 1.0.1
+version: 1.0.2
 homepage: https://github.com/matszafraniec/flutter_device_region
 
 environment:


### PR DESCRIPTION
didn't return at all before